### PR TITLE
frfr: check for pals before scrying mutuals

### DIFF
--- a/desk/app/frfr.hoon
+++ b/desk/app/frfr.hoon
@@ -177,7 +177,9 @@ my peers attests that the ship is definitely fake (%0) the confidence goes to 0.
 ++  on-init
   ^-  (quip card _this)
   ~>  %bout.[0 '%frfr +on-init']
-  =.  neighbors.state  .^((set @p) %gx /(scot %p our.bowl)/pals/(scot %da now.bowl)/mutuals/noun)
+  =.  neighbors.state  ?.  .^(? %gu /=pals=/$)
+                         *(set @p)
+                       .^((set @p) %gx /=pals=/mutuals/noun)
   :_  this
   ^-  (list card)
   %-  zing


### PR DESCRIPTION
Runs the "existence" scry with care `%gu` to check whether Pals is installed and running before attempting to scry mutuals from pals. 

As implemented, there's no accommodation for starting pals later. Pals also doesn't offer (as of this writing, 2 Aug. 2023) a subscription path to be updated when leeches/targets become mutuals, so it's not clear how we'd add that except by watching both and checking their intersection on every update.
